### PR TITLE
Improve error handling on remaining check

### DIFF
--- a/app/(home)/components/MainContent.tsx
+++ b/app/(home)/components/MainContent.tsx
@@ -15,6 +15,7 @@ import {
 import { getRandomExamples } from '@/lib/data';
 import { fetchPost } from '@/lib/utils';
 import { SuggestResponse } from '@/types';
+import toast from 'react-hot-toast';
 import { Loading } from './Loading';
 import { PromptInput } from './PromptInput';
 import { RemainingInfo } from './RemainingInfo';
@@ -88,7 +89,8 @@ export function MainContent({
       else throw new Error('Failed to check remaining');
     } catch (err) {
       console.error(err);
-      setRemaining(null); // TODO: better fail state
+      setRemaining(null);
+      toast.error('Failed to check remaining');
     }
   };
 


### PR DESCRIPTION
## Summary
- show toast when fetching remaining jokes fails so users see the error

## Testing
- `npm run lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68589acf8e6883249893bb32714239b9