### PR TITLE
Show header intro only on homepage

### DIFF
--- a/app/(home)/components/MainContent.tsx
+++ b/app/(home)/components/MainContent.tsx
@@ -97,7 +97,7 @@ export function MainContent({
   }, [isSignedIn]);
 
   return (
-    <>
+    <div className="pt-4">
       <div className="mb-10 lg:mb-12">
         <PromptInput
           value={prompt}
@@ -136,6 +136,6 @@ export function MainContent({
           onResubmit={handleSubmit}
         />
       )}
-    </>
+    </div>
   );
 }

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -14,7 +14,7 @@ export default async function HomePage() {
 
   return (
     <Container>
-      <Header />
+      <Header showDescription />
       <MainContent
         examples={examples}
         isSignedIn={user != null}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -3,8 +3,8 @@ import { Container } from '@/components/Container';
 import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
 import { getSubscription, getUser } from '@/lib/supabase-server';
-import { UpdateSubscriptionButton } from './components/UpdateSubscriptionButton';
 import { SubscribeButton } from './components/SubscribeButton';
+import { UpdateSubscriptionButton } from './components/UpdateSubscriptionButton';
 
 export default async function AccountPage() {
   const [user, subscription] = await Promise.all([
@@ -20,7 +20,7 @@ export default async function AccountPage() {
   return (
     <Container>
       <Header />
-      <div className="border-t border-gray-200 pt-8 space-y-6">
+      <div className="border-t border-gray-100 pt-8 space-y-8">
         <div className="space-y-2">
           <h2 className="text-sm font-bold uppercase tracking-wider">
             Account Details

--- a/app/p/[id]/page.tsx
+++ b/app/p/[id]/page.tsx
@@ -39,7 +39,7 @@ export default async function PunchlinePage({ params: { id } }: Props) {
   return (
     <Container>
       <Header />
-      <div className="border-t border-gray-200 pt-8">
+      <div className="border-t border-gray-100 pt-8">
         <div className="p-6 sm:p-8 bg-slate-50 border border-slate-200 rounded-2xl">
           <div className="mb-4 sm:mb-6 flex items-start space-x-3">
             <div className="flex h-8 w-8 shrink-0 select-none items-center justify-center rounded-md border shadow bg-background">

--- a/app/saved/page.tsx
+++ b/app/saved/page.tsx
@@ -16,7 +16,7 @@ export default async function SavedJokesPage() {
   return (
     <Container>
       <Header />
-      <div className="border-t border-gray-200 pt-8">
+      <div className="border-t border-gray-100 pt-8">
         {jokes.length === 0 ? (
           <div className="px-6 py-8 sm:px-8 sm:py-10 bg-slate-100 rounded-2xl">
             <div className="text-sm font-bold uppercase tracking-wider text-center">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,11 @@
 import { AuthNav } from './AuthNav';
 import { Logo } from './Logo';
 
-export function Header() {
+type HeaderProps = {
+  showDescription?: boolean;
+};
+
+export function Header({ showDescription = false }: HeaderProps) {
   return (
     <div className="mb-8">
       <div className="mb-1.5 flex items-center justify-between space-x-2">
@@ -9,10 +13,12 @@ export function Header() {
         {/* @ts-expect-error */}
         <AuthNav />
       </div>
-      <p>
-        Meet your new AI comedy writing partner. You provide a joke set-up, and
-        it generates the zingers.
-      </p>
+      {showDescription && (
+        <p>
+          Meet your new AI comedy writing partner. You provide a joke set-up,
+          and it generates the zingers.
+        </p>
+      )}
     </div>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,11 +1,11 @@
 import { AuthNav } from './AuthNav';
 import { Logo } from './Logo';
 
-type HeaderProps = {
+interface Props {
   showDescription?: boolean;
-};
+}
 
-export function Header({ showDescription = false }: HeaderProps) {
+export function Header({ showDescription = false }: Props) {
   return (
     <div className="mb-4">
       <div className="mb-1.5 flex items-center justify-between space-x-2">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,7 +7,7 @@ type HeaderProps = {
 
 export function Header({ showDescription = false }: HeaderProps) {
   return (
-    <div className="mb-8">
+    <div className="mb-4">
       <div className="mb-1.5 flex items-center justify-between space-x-2">
         <Logo />
         {/* @ts-expect-error */}


### PR DESCRIPTION
## Summary
- make `Header` accept a `showDescription` prop
- display description only when prop is true
- enable description on the homepage

## Testing
- `npm run lint` *(fails: prompts for interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_685c42ca44bc8324a9f4b17aeb48bafc